### PR TITLE
add simple drawing functions for flickgame mega scripts

### DIFF
--- a/play3e.html
+++ b/play3e.html
@@ -349,6 +349,22 @@ function redraw(){
     redraw();
   }
   
+  function overlayImage(sourceIndex, transparentColorIndex){
+    var transparent=transparentColorIndex.toString(16);
+    var s0=gameState.imageDats[currentIndex];
+    var s1=gameState.imageDats[sourceIndex-1];
+    var s2=""
+    for (i=0;i<s0.length;i++){
+      if (s1[i]==transparent){
+        s2+=s0[i];
+      } else {
+        s2+=s1[i];
+      }
+    }
+    gameState.imageDats[currentIndex] = s2;
+    drawCanvasPixels(s2, imageCtxts[currentIndex]);
+  }
+  
   function runScript(s){
     gotoset=false;
     var result = eval(s);

--- a/play3e.html
+++ b/play3e.html
@@ -287,7 +287,58 @@ function redraw(){
     gotoset=true;
     currentIndex+=n;
   }
-
+  
+  function box(x,y,w,h,c){
+    var ch=c.toString(16);
+    imageCtxts[currentIndex].fillStyle=colorPalette[c];
+    imageCtxts[currentIndex].fillRect(x,y,w,h);
+    var str = gameState.imageDats[currentIndex];
+    for (var row=y;row<(y+h);row++){
+      var p = x+200*row;
+      var q = x+w+200*row;
+      str = str.substr(0,p)+ch.repeat(w)+str.substr(q);
+    }
+    gameState.imageDats[currentIndex]=str;
+  }
+  
+  function circle(x,y,r,c){
+    for (var dy=-r;dy<(r+1);dy++){
+      var dx=Math.floor(Math.sqrt((r+0.4)*(r+0.4) - dy*dy));
+      box(x-dx,y+dy,2*dx+1,1,c);
+    }
+  }
+  
+  function line(x0,y0,x1,y1,c){
+    dx=x1-x0;
+    dy=y1-y0;
+    if (dx==0 && dy==0){
+      box(x0,y0,1,1,c);     
+    } else if (Math.abs(dx)>Math.abs(dy)){
+      var left = Math.min(x0,x1);
+      var right = Math.max(x0,x1);
+      for (var x=left;x<=right;x++){
+        y=Math.round(y0+dy*(x-x0)/dx);
+        box(x,y,1,1,c);        
+      }
+    } else {
+      var top = Math.min(y0,y1);
+      var bottom = Math.max(y0,y1);
+      for (var y=top;y<=bottom;y++){
+        x=Math.round(x0+dx*(y-y0)/dy);
+        box(x,y,1,1,c);        
+      }
+    }
+  }
+  
+  function resetImage(){
+    var descriptionArray = gameState.canvasses[currentIndex];
+    var descriptionString = RLE_decode(descriptionArray);
+    gameState.imageDats[currentIndex]=descriptionString;
+    ctx=imageCtxts[currentIndex];
+    drawCanvasPixels(descriptionString, ctx);
+    redraw();
+  }
+  
   function runScript(s){
     gotoset=false;
     var result = eval(s);
@@ -481,19 +532,23 @@ function RLE_decode(encoded) {
 var images = new Array();
 var imageCtxts = new Array();
 
+function drawCanvasPixels(descriptionString, ctx){
+  for (var j=0;j<descriptionString.length;j++){
+    var x = j%200;
+    var y = Math.floor(j/200);
+    var ch=descriptionString[j];
+    var colIndex = parseInt(ch,16);
+    ctx.fillStyle=colorPalette[colIndex];
+    ctx.fillRect(x,y,1,1);
+  }
+}
+
 function printCanvas(descriptionString){
     var canvas = document.createElement('canvas');
     canvas.width="200";
     canvas.height="100";
     var ctx=canvas.getContext("2d");
-    for (var j=0;j<descriptionString.length;j++){
-      var x = j%200;
-      var y = Math.floor(j/200);
-      var ch=descriptionString[j];
-      var colIndex = parseInt(ch,16);
-      ctx.fillStyle=colorPalette[colIndex];
-      ctx.fillRect(x,y,1,1);
-    }
+    drawCanvasPixels(descriptionString, ctx)
     return [canvas,ctx];
 }
 

--- a/play3e.html
+++ b/play3e.html
@@ -289,22 +289,32 @@ function redraw(){
   }
   
   function box(x,y,w,h,c){
+    var x0=Math.round(x);
+    var y0=Math.round(y);
+    var x1=Math.round(x+w);
+    var y1=Math.round(y+h);
     var ch=c.toString(16);
     imageCtxts[currentIndex].fillStyle=colorPalette[c];
-    imageCtxts[currentIndex].fillRect(x,y,w,h);
+    imageCtxts[currentIndex].fillRect(x0,y0,x1-x0,y1-y0);
     var str = gameState.imageDats[currentIndex];
-    for (var row=y;row<(y+h);row++){
-      var p = x+200*row;
-      var q = x+w+200*row;
-      str = str.substr(0,p)+ch.repeat(w)+str.substr(q);
+    for (var row=y0;row<y1;row++){
+      var p = x0+200*row;
+      var q = x1+200*row;
+      str = str.substr(0,p)+ch.repeat(q-p)+str.substr(q);
     }
     gameState.imageDats[currentIndex]=str;
   }
   
   function circle(x,y,r,c){
-    for (var dy=-r;dy<(r+1);dy++){
-      var dx=Math.floor(Math.sqrt((r+0.4)*(r+0.4) - dy*dy));
-      box(x-dx,y+dy,2*dx+1,1,c);
+    var top=Math.round(y-r);
+    var bottom=Math.round(y+r);
+    for (var row=top;row<=bottom;row++){
+      var dy=row-y;
+      var dx2=(r+0.4)*(r+0.4) - dy*dy;
+      if (dx2>0){
+        dx=Math.sqrt(dx2);
+        box(x+0.5-dx,row,2*dx,1,c);
+      }
     }
   }
   
@@ -314,15 +324,15 @@ function redraw(){
     if (dx==0 && dy==0){
       box(x0,y0,1,1,c);     
     } else if (Math.abs(dx)>Math.abs(dy)){
-      var left = Math.min(x0,x1);
-      var right = Math.max(x0,x1);
+      var left = Math.round(Math.min(x0,x1));
+      var right = Math.round(Math.max(x0,x1));
       for (var x=left;x<=right;x++){
         y=Math.round(y0+dy*(x-x0)/dx);
         box(x,y,1,1,c);        
       }
     } else {
-      var top = Math.min(y0,y1);
-      var bottom = Math.max(y0,y1);
+      var top = Math.round(Math.min(y0,y1));
+      var bottom = Math.round(Math.max(y0,y1));
       for (var y=top;y<=bottom;y++){
         x=Math.round(x0+dx*(y-y0)/dy);
         box(x,y,1,1,c);        


### PR DESCRIPTION
This adds four new scripting functions to flickgame-mega, adding the capability to modify the images. The new functions are

- box: Draw a rectangle on the current image
- circle: Draw a filled circle on the current image
- line: Draw a line on the current image
- resetImage: Return the current image to its original state

One tricky design choice is indexing on the image coordinates, and also on colours. I've used zero-based indexes on both, as that's what the underlying data structures use, but it's maybe inconsistent with the numbering given to images (e.g. as used by the goto function).