### PR TITLE
Prevent unnecessary scrollbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -1027,7 +1027,7 @@ body {
                  }
                  ul {
                  list-style-type: none;
-                 overflow:hidden; overflow-y:scroll;
+                 overflow:hidden; overflow-y:auto;
                  }
                  input {
                  background-color: black;


### PR DESCRIPTION
Look at that ugly useless scrollbar not even scrolling anything

![obrazek](https://user-images.githubusercontent.com/4580066/96856800-9d17dc00-145e-11eb-9f2b-897065c95f1e.png)

setting `scroll` to `auto` will hide useless scrollbars